### PR TITLE
feat: add support for custom patches

### DIFF
--- a/src/patch.js
+++ b/src/patch.js
@@ -124,7 +124,6 @@ export const getCustomPatchVersions = async (options) => {
 				versions.push(file);
 			}
 		}
-		versions.sort(cmp);
 	}
 
 	return versions;


### PR DESCRIPTION
Moved custom patches to a different directory `~/.searchspring/snapfu-patches/custom/{version}` instead of `~/.searchspring/snapfu-patches/{framework}/{version}` so that existing versions of snapfu don't break when reading new snapfu-patches structure. Custom patches are not listed in the `snapfu patch list` command. `snapfu patch apply [version]` and `snapfu patch apply latest` should not be affected. Only specifying a custom patch via `snapfu patch apply [custom-patch-name]` should be allowed and also not alter package.json version.