### PR TITLE
Update publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: "0"
-          token: ${{ secrets.MACHINE_TOKEN }}
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Set Github credentials
         run: |


### PR DESCRIPTION
Switching to deploy key instead of authentication token - hoping this will still use the GITHUB_TOKEN (which auto prevents looping of actions).