### PR TITLE
Prevent Workflow Infinite Loop

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: "0"
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
+          token: ${{ secrets.MACHINE_TOKEN }}
 
       - name: Set Github credentials
         run: |

--- a/.versionrc
+++ b/.versionrc
@@ -1,4 +1,5 @@
 {
+  "releaseCommitMessageFormat": "chore(release): {{currentTag}} [skip actions]",
   "types": [
     {"type": "chore", "section":"Others", "hidden": true},
     {"type": "revert", "section":"Reverts", "hidden": false},


### PR DESCRIPTION
Using the distribution key did not prevent release loop.

Attempting to add a "stop" word to the release commit message to prevent the infinite loop (and retain bypass of ruleset) on publish workflow.

https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs