### PR TITLE
Scaffolds Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ snapfu patch <command> <args> [--options]
 
 **Subcommands:**
 - `apply` - Apply patch version (version or latest)
+  - `--ci` - Run without interactive prompts
+  - `--scaffold` - Patch a scaffold project (skips siteId validation)
 - `list` - List available versions for project
 - `fetch` - Fetch latest versions of patches
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -49,7 +49,8 @@ async function parseArgumentsIntoOptions(rawArgs) {
 	const command = args._[0];
 
 	// scaffold projects contain placeholder siteId values - skip siteId validation when patching them
-	const context = await getContext(process.cwd(), { skipSiteIdValidation: args['--scaffold'] });
+	const skipSiteIdValidation = Boolean(args['--scaffold']) && command === 'patch' && args._[1] === 'apply';
+	const context = await getContext(process.cwd(), { skipSiteIdValidation });
 
 	// exit on commands that require a Snap project
 	const orgRequiredCommands = ['badge', 'badges', 'recs', 'recommendation', 'recommendations', 'secret', 'secrets', 'patch'];

--- a/src/cli.js
+++ b/src/cli.js
@@ -32,6 +32,7 @@ async function parseArgumentsIntoOptions(rawArgs) {
 				'--dev': Boolean,
 				'--zone': String,
 				'--ci': Boolean,
+				'--scaffold': Boolean,
 				'--updater': Boolean,
 				'--secret-key': String,
 				'--secrets-ci': String,
@@ -47,7 +48,8 @@ async function parseArgumentsIntoOptions(rawArgs) {
 
 	const command = args._[0];
 
-	const context = await getContext(process.cwd());
+	// scaffold projects contain placeholder siteId values - skip siteId validation when patching them
+	const context = await getContext(process.cwd(), { skipSiteIdValidation: args['--scaffold'] });
 
 	// exit on commands that require a Snap project
 	const orgRequiredCommands = ['badge', 'badges', 'recs', 'recommendation', 'recommendations', 'secret', 'secrets', 'patch'];
@@ -212,6 +214,7 @@ jobs:
 			secretKey,
 			secrets: args['--secrets-ci'],
 			ci: args['--ci'],
+			scaffold: args['--scaffold'],
 			updater: args['--updater'],
 		},
 		context,

--- a/src/context.js
+++ b/src/context.js
@@ -6,10 +6,10 @@ import chalk from 'chalk';
 import { auth } from './login.js';
 import { commandOutput } from './utils/index.js';
 
-export async function getContext(dir) {
+export async function getContext(dir, options = {}) {
 	let project, integration, branch, branchList, remote, organization, name;
 	try {
-		project = await getProject(dir);
+		project = await getProject(dir, options);
 		integration = project?.packageJSON?.athos || project?.packageJSON?.searchspring;
 	} catch (err) {
 		// do nothing
@@ -60,7 +60,9 @@ export async function getContext(dir) {
 	};
 }
 
-export async function getProject(dir) {
+export async function getProject(dir, options = {}) {
+	const { skipSiteIdValidation } = options;
+
 	try {
 		const [packageFile] = await getClosest(dir || process.cwd(), 'package.json');
 
@@ -126,6 +128,10 @@ export async function getProject(dir) {
 			}
 
 			const siteId = parsedContents[projectDetails.org].siteId;
+			if (skipSiteIdValidation) {
+				// scaffold projects contain placeholder siteId values that are not expected to be valid
+				return projectDetails;
+			}
 			if (siteId && typeof siteId === 'string') {
 				const isValid =
 					projectDetails.org === 'athos'

--- a/src/context.test.js
+++ b/src/context.test.js
@@ -161,4 +161,42 @@ describe('getContext function', () => {
 		expect(context).toHaveProperty('integration');
 		expect(context.project).toHaveProperty('version');
 	});
+	it('exits when the siteId is invalid', async () => {
+		const mockPackageJSON = {
+			athos: {
+				siteId: 'xxxxxx',
+				framework: 'preact',
+				platform: 'bigcommerce',
+				tags: ['finder'],
+			},
+		};
+		await fsp.writeFile(packagePath, JSON.stringify(mockPackageJSON));
+
+		const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+
+		await getContext(projectDir);
+		expect(exitSpy).toHaveBeenCalledWith(1);
+
+		exitSpy.mockRestore();
+	});
+	it('does not validate the siteId when skipSiteIdValidation is used', async () => {
+		const mockPackageJSON = {
+			athos: {
+				siteId: 'xxxxxx',
+				framework: 'preact',
+				platform: 'bigcommerce',
+				tags: ['finder'],
+			},
+		};
+		await fsp.writeFile(packagePath, JSON.stringify(mockPackageJSON));
+
+		const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+
+		const context = await getContext(projectDir, { skipSiteIdValidation: true });
+		expect(exitSpy).not.toHaveBeenCalled();
+		expect(context.project.org).toBe('athos');
+		expect(context.integration.siteId).toBe('xxxxxx');
+
+		exitSpy.mockRestore();
+	});
 });

--- a/src/help.js
+++ b/src/help.js
@@ -54,6 +54,8 @@ const patchText = `Usage: snapfu patch ${chalk.white('<' + chalk.underline('comm
 These are the snapfu patch commands
 
     ${chalk.whiteBright('apply')}                         Apply patch version (version or latest)
+        ${chalk.green('--ci')}
+        ${chalk.green('--scaffold')}                Patch a scaffold project (skips siteId validation)
     ${chalk.whiteBright('list')}                          List available versions for project
     ${chalk.whiteBright('fetch')}                         Fetch latest versions of patches`;
 

--- a/src/help.js
+++ b/src/help.js
@@ -54,7 +54,7 @@ const patchText = `Usage: snapfu patch ${chalk.white('<' + chalk.underline('comm
 These are the snapfu patch commands
 
     ${chalk.whiteBright('apply')}                         Apply patch version (version or latest)
-        ${chalk.green('--ci')}
+        ${chalk.green('--ci')}                Run without interactive prompts
         ${chalk.green('--scaffold')}                Patch a scaffold project (skips siteId validation)
     ${chalk.whiteBright('list')}                          List available versions for project
     ${chalk.whiteBright('fetch')}                         Fetch latest versions of patches`;


### PR DESCRIPTION
This pull request introduces support for patching scaffold projects by adding a `--scaffold` flag to the `snapfu patch apply` command. This allows users to skip siteId validation, which is useful for scaffold projects that use placeholder siteId values. The changes also update the CLI, context handling, and documentation to support this new workflow, and include new tests for this behavior.

**Support for scaffold projects and siteId validation:**

* Added a `--scaffold` flag to the `patch apply` command, allowing users to patch scaffold projects and skip siteId validation (`README.md`, `src/help.js`, `src/cli.js`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R82-R83) [[2]](diffhunk://#diff-bd44dcfddf871ebcdee89bc81d081b7afb58b9756c40d0516b3cbe255044716dR57-R58) [[3]](diffhunk://#diff-a3751a8ca1ab5bdf5d4bb6b4c3861d9a81205bc01b080e57301090b6e8b34165R35) [[4]](diffhunk://#diff-a3751a8ca1ab5bdf5d4bb6b4c3861d9a81205bc01b080e57301090b6e8b34165R217)
* Updated the `getContext` and `getProject` functions to accept an option to skip siteId validation when the `--scaffold` flag is used (`src/context.js`). [[1]](diffhunk://#diff-f00be3776778d4a72e4f0720b43138c8a7f09e508f31a1987b8952410b315518L9-R12) [[2]](diffhunk://#diff-f00be3776778d4a72e4f0720b43138c8a7f09e508f31a1987b8952410b315518L63-R65) [[3]](diffhunk://#diff-f00be3776778d4a72e4f0720b43138c8a7f09e508f31a1987b8952410b315518R131-R134)

**Testing improvements:**

* Added tests to ensure that siteId validation is skipped when `skipSiteIdValidation` is set, and that invalid siteIds cause the process to exit when not skipped (`src/context.test.js`).