### PR TITLE
Release Patch (scaffold flag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ snapfu patch <command> <args> [--options]
   - `--ci` - Run without interactive prompts
   - `--scaffold` - Patch a scaffold project (skips siteId validation)
 - `list` - List available versions for project
+  - `--scaffold` - Target a scaffold project (skips siteId validation)
 - `fetch` - Fetch latest versions of patches
+  - `--scaffold` - Target a scaffold project (skips siteId validation)
 
 ### `login` - OAuth with GitHub
 OAuths with GitHub to allow for creating repositories when using the init command

--- a/src/cli.js
+++ b/src/cli.js
@@ -49,7 +49,7 @@ async function parseArgumentsIntoOptions(rawArgs) {
 	const command = args._[0];
 
 	// scaffold projects contain placeholder siteId values - skip siteId validation when patching them
-	const skipSiteIdValidation = Boolean(args['--scaffold']) && command === 'patch' && args._[1] === 'apply';
+	const skipSiteIdValidation = Boolean(args['--scaffold']) && command === 'patch';
 	const context = await getContext(process.cwd(), { skipSiteIdValidation });
 
 	// exit on commands that require a Snap project

--- a/src/help.js
+++ b/src/help.js
@@ -55,7 +55,6 @@ These are the snapfu patch commands
 
     ${chalk.whiteBright('apply')}                         Apply patch version (version or latest)
         ${chalk.green('--ci')}                Run without interactive prompts
-        ${chalk.green('--scaffold')}                Patch a scaffold project (skips siteId validation)
     ${chalk.whiteBright('list')}                          List available versions for project
     ${chalk.whiteBright('fetch')}                         Fetch latest versions of patches`;
 


### PR DESCRIPTION
This pull request makes improvements to the handling and documentation of the `--scaffold` option for `snapfu patch` commands. The main focus is on clarifying when the `--scaffold` flag can be used and ensuring consistent behavior across commands.

**Documentation and Help Updates:**

* Updated the `README.md` to clarify that the `--scaffold` flag can be used with both the `list` and `fetch` commands, not just `patch`, and adjusted option descriptions for consistency.
* Removed the `--scaffold` flag from the help output for the `apply` subcommand, reflecting that it's now available at the command level rather than just for `apply`.

**Command Parsing Logic:**

* Changed the logic in `parseArgumentsIntoOptions` (in `src/cli.js`) so that `--scaffold` skips siteId validation for all `patch` subcommands, not just `patch apply`.